### PR TITLE
Allow the destruction of the s3 buckets when they are not empty.  

### DIFF
--- a/terraform/backend/init.tf
+++ b/terraform/backend/init.tf
@@ -23,6 +23,12 @@ resource "aws_s3_bucket" "tfstate" {
   versioning {
     enabled = true # Prevent from deleting tfstate file
   }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  force_destroy = true
 }
 
 # DynamoDB for terraform state lock

--- a/terraform/thanos-stack/modules/chain-config/s3.tf
+++ b/terraform/thanos-stack/modules/chain-config/s3.tf
@@ -6,6 +6,8 @@ resource "random_string" "randomname" {
 
 resource "aws_s3_bucket" "config_files" {
   bucket = "${var.thanos_stack_name}-config-${random_string.randomname.result}"
+
+  force_destroy = true 
 }
 
 resource "aws_s3_bucket_public_access_block" "public_access" {


### PR DESCRIPTION
**Context**
 When running `terraform destroy` to destroy the resources, we will fail at the S3 destroying step because S3 buckets prevent destroying when they're not empty.

So, I modified the terraform code to support this case by adding the `force_destroy` flag.