### PR TITLE
feat(thanos-stack-chart): upgrade external secrets from v0.16.0 to v017.0

### DIFF
--- a/charts/thanos-stack/templates/external-secret.yaml
+++ b/charts/thanos-stack/templates/external-secret.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: thanos-ext-secret

--- a/charts/thanos-stack/templates/secretstore.yaml
+++ b/charts/thanos-stack/templates/secretstore.yaml
@@ -1,4 +1,4 @@
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: {{ include "thanos-stack.fullname" . }}-secretstore


### PR DESCRIPTION
related to the breaking changes: https://github.com/external-secrets/external-secrets/releases
I've tested to deploy the chain successfully.

The new manifest looks like:
![image](https://github.com/user-attachments/assets/503651b4-ffca-4795-968d-d41e23212cfa)
